### PR TITLE
fix building on Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Clone and Submodules
 ============
 
 ```
-git clone <the repo>
+git clone https://github.com/libvmtrace/libvmtrace
+cd libvmtrace
 git submodule init
 git submodule update
 
@@ -35,7 +36,7 @@ cmake -DENABLE_KVM=OFF ..
 make
 make install
 
-cd ../librdkafka
+cd ../../librdkafka
 ./configure
 make
 make install

--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -6,8 +6,8 @@ PLUGINS = plugins/SyscallLogger.cpp \
 	  plugins/ProcessListLogger.cpp \
 	  plugins/ProcessChangeLogger.cpp
 
-LDADD = -lm $(LIBS) $(GLIB_LIBS) $(DEPS_LDFLAGS) -lssl -lcrypto  -lboost_system -lboost_regex -lboost_filesystem -lboost_program_options -lcurl
-LDADD += -lvmtrace -lxentoollog -lxenctrl -lxenlight -ldwarf -lelf -lnetfilter_queue -lrdkafka++
+LDADD = -lm $(LIBS) $(GLIB_LIBS) $(DEPS_LDFLAGS) -lssl -lcrypto  -lboost_system -lboost_regex -lboost_filesystem -lboost_program_options
+LDADD += -lvmtrace -lxentoollog -lxenctrl -lxenlight -ldwarf -lelf -lnetfilter_queue -lrdkafka++ -lcurl
 
 bin_PROGRAMS = saracenia_app saracenia2_app dingfest_app code_section_integrity_app code_section_integrity_binary_app git_detect_app measurment_app measurment_pf_app ssh_key_extraction_app csec_app
 

--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -9,7 +9,7 @@ PLUGINS = plugins/SyscallLogger.cpp \
 LDADD = -lm $(LIBS) $(GLIB_LIBS) $(DEPS_LDFLAGS) -lssl -lcrypto  -lboost_system -lboost_regex -lboost_filesystem -lboost_program_options
 LDADD += -lvmtrace -lxentoollog -lxenctrl -lxenlight -ldwarf -lelf -lnetfilter_queue -lrdkafka++ -lcurl
 
-bin_PROGRAMS = saracenia_app saracenia2_app dingfest_app code_section_integrity_app code_section_integrity_binary_app git_detect_app measurment_app measurment_pf_app ssh_key_extraction_app csec_app
+bin_PROGRAMS = saracenia_app saracenia2_app dingfest_app code_section_integrity_app code_section_integrity_binary_app git_detect_app ssh_key_extraction_app csec_app
 
 saracenia_app_SOURCES = saracenia.cpp \
 						ssh_helper/SSHHelper.cpp
@@ -20,10 +20,6 @@ saracenia2_app_SOURCES = saracenia2.cpp \
 saracenia2_app_LDADD = $(LDADD) -lssh
 
 dingfest_app_SOURCES = dingfest.cpp $(PLUGINS)
-
-measurment_app_SOURCES = measurment.cpp $(PLUGINS)
-
-measurment_pf_app_SOURCES = measurment_pf.cpp $(PLUGINS)
 
 code_section_integrity_app_SOURCES = code_section_integrity.cpp
 code_section_integrity_app_LDADD = $(LDADD)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,8 +2,8 @@ AM_CXXFLAGS = -pg -fpic  -O3 $(GLIB_CFLAGS) $(DEPS_CFLAGS)  -lpthread -I../rapid
 
 AM_LDFLAGS = -L$(top_builddir)/src/.libs/
 
-LDADD = -lm $(LIBS) $(GLIB_LIBS) $(DEPS_LDFLAGS) -lssl -lcrypto  -lboost_system -lboost_regex -lboost_filesystem -lboost_program_options  -lcurl
-LDADD += -lvmtrace -lxentoollog -lxenctrl -lxenlight -ldwarf -lelf -lnetfilter_queue -lrdkafka++
+LDADD = -lm $(LIBS) $(GLIB_LIBS) $(DEPS_LDFLAGS) -lssl -lcrypto  -lboost_system -lboost_regex -lboost_filesystem -lboost_program_options
+LDADD += -lvmtrace -lxentoollog -lxenctrl -lxenlight -ldwarf -lelf -lnetfilter_queue -lrdkafka++ -lcurl
 
 bin_PROGRAMS = static_test_app static_test_injection_app static_test_kafka_commander_app static_test_altp2m_app memory_test_app static_elasticsearch_test_app
 


### PR DESCRIPTION
Fixes build errors encountered on a clean Ubuntu 18.04 VM:
1. move -lcurl to the very end of the LDADD list
2. remove nonexisting targets in /apps

Plus minor changes to the  build instructions.