### PR TITLE
Added support for resolving of non-function ELF exports

### DIFF
--- a/src/sys/ElfHelper.cpp
+++ b/src/sys/ElfHelper.cpp
@@ -60,7 +60,7 @@ namespace libvmtrace
 		return 0;
 	}
 
-	addr_t ElfHelper::elf_get_symbol_addr(void* memory, const char* section,const char* symbol) 
+	addr_t ElfHelper::elf_get_symbol_addr(void* memory, const char* section, const char* symbol, const bool only_functions) 
 	{
 		unsigned int i=0;
 		Elf64_Ehdr* ehdr = (Elf64_Ehdr*)memory;
@@ -84,7 +84,7 @@ namespace libvmtrace
 				Elf64_Sym* s = (Elf64_Sym*) ((char*)memory + sect[i].sh_offset);
 				for(symit=0; symit<count; symit++)
 				{
-					if (!((ELF32_ST_BIND(STB_GLOBAL) | ELF64_ST_TYPE(STT_FUNC)) & s[symit].st_info))
+					if (only_functions && !((ELF32_ST_BIND(STB_GLOBAL) | ELF64_ST_TYPE(STT_FUNC)) & s[symit].st_info))
 						continue;
 					if (s[symit].st_value == 0)
 						continue;

--- a/src/sys/ElfHelper.hpp
+++ b/src/sys/ElfHelper.hpp
@@ -13,7 +13,7 @@ namespace libvmtrace
 	public:
 		ElfHelper() = default;
 		int elf_check_file(Elf64_Ehdr* hdr);
-		addr_t elf_get_symbol_addr(void* memory, const char* section,const char* symbol);
+		addr_t elf_get_symbol_addr(void* memory, const char* section, const char* symbol, const bool only_functions = true);
 		size_t get_section_offset(void* memory, const char* section);
 		char* map_file(const char* file_name, off_t offset, int*);
 	};

--- a/src/sys/LinuxVM.hpp
+++ b/src/sys/LinuxVM.hpp
@@ -156,8 +156,8 @@ namespace libvmtrace
 
 			void Stop();
 
-			addr_t GetSymbolAddrVa(const std::string binaryPath, const Process& p, const std::string symbolName);
-			addr_t GetSymbolAddrPa(const std::string binaryPath, const Process& p, const std::string symbolName);
+			addr_t GetSymbolAddrVa(const std::string binaryPath, const Process& p, const std::string symbolName, const bool onlyFunctions = true);
+			addr_t GetSymbolAddrPa(const std::string binaryPath, const Process& p, const std::string symbolName, const bool onlyFunctions = true);
 			
 			void PopulatePageFaultAdress(const vmi_pid_t pid, const addr_t target, EventListener* evl);
 			status_t InvokePageFault(uint64_t total_address_per_inst);


### PR DESCRIPTION
This patch introduces an additional parameter for LinuxVM::GetSymbolVa, that allows the caller to skip some constraints on the entry in the ELF export directory.
By doing this, we can access exported variables and share memory across (virtual) machine bounds.