### PR TITLE
Resolve file names correctly across mountpoints

### DIFF
--- a/apps/csec.cpp
+++ b/apps/csec.cpp
@@ -45,10 +45,10 @@ int main(int argc, char* argv[])
 	SystemMonitor sm(vm_id, true);
 	_sm = &sm;
 
-	Altp2mBasic* altp2mbasic = new Altp2mBasic(sm);
-	sm.SetBPM(altp2mbasic, altp2mbasic->GetType());
+	Int3 *int3 = new Int3(sm);
+	sm.SetBPM(int3, int3->GetType());
 	sm.Init();
-	altp2mbasic->Init();
+	int3->Init();
 	sm.Loop();
 
 	LinuxVM linux(&sm);

--- a/src/sys/LinuxVM.cpp
+++ b/src/sys/LinuxVM.cpp
@@ -404,7 +404,7 @@ namespace libvmtrace
 		vmi_read_64_va(vmi, fdt + _fd_offset, 0, &fd);
 
 		// int count = 0;
-		int minfd = 3;
+		int minfd = 0;
 		if( filterfd >= 0 ) {  // if filterfd is specified, return only this file (if fd exists)
 			minfd = filterfd; 
 			max_fds = std::min(minfd+1, (int)max_fds);

--- a/src/sys/LinuxVM.cpp
+++ b/src/sys/LinuxVM.cpp
@@ -404,9 +404,9 @@ namespace libvmtrace
 			minfd = filterfd; 
 			max_fds = std::min(minfd+1, (int)max_fds);
 		}
-		std::cout << "minfd: " << minfd << ", maxfd: " << max_fds << "\n";
+		//std::cout << "minfd: " << minfd << ", maxfd: " << max_fds << "\n";
 		
-		for(uint32_t it = 3; it < max_fds ; it++)
+		for(uint32_t it = minfd; it < max_fds ; it++)
 		{
 			addr_t file = 0;
 			uint32_t mode;

--- a/src/sys/LinuxVM.hpp
+++ b/src/sys/LinuxVM.hpp
@@ -179,6 +179,7 @@ namespace libvmtrace
 	private:
 		addr_t _tgid_offset, _name_offset, _mm_offset, _tasks_offset, _parent_offset, _pgd_offset, _real_cred_offset, _uid_offset, _fs_offset, _pwd_offset;
 		addr_t _dentry_d_name_offset, _dentry_parent_offset;
+		addr_t _mount_mnt_mountpoint_offset, _mount_mnt_parent_offset, _mount_mnt_offset;
 		addr_t _files_offset, _fdt_offset, _fd_offset, _f_mode_offset, _f_path_offset;
 		addr_t _private_data_offset, _sk_offset, _u1_offset, _u3_offset;
 		addr_t _vm_end_offset, _vm_flags_offset, _vm_file_offset, _vm_pgoff_offset, _vm_next_offset, _exe_file_offset;
@@ -188,7 +189,7 @@ namespace libvmtrace
 		addr_t _socket_type_offset, _socket_family;
 
 		std::string d_path(addr_t path, vmi_instance_t vmi) const;
-		uint32_t create_path(addr_t dentry, char* buf, vmi_instance_t vmi) const;
+		uint32_t create_path(addr_t dentry, addr_t mnt, char* buf, vmi_instance_t vmi) const;
 		Process taskstruct_to_Process(addr_t current_process, vmi_instance_t vmi) const;
 
 		addr_t GetSyscallAddrVA(unsigned int syscall_nr, bool is32bit, vmi_instance_t vmi);

--- a/src/sys/LinuxVM.hpp
+++ b/src/sys/LinuxVM.hpp
@@ -138,9 +138,10 @@ namespace libvmtrace
 	public:
 		LinuxVM(SystemMonitor* sm);
 
+        	Process GetCurrentProcess(addr_t current_process) const;
 		std::vector<Process> GetProcessList();
 		std::vector<net::NetworkConnection> GetNetworkConnections(const Process& p, const ConnectionType type);
-		std::vector<OpenFile> GetOpenFiles(const Process& p);
+		std::vector<OpenFile> GetOpenFiles(const Process& p, int filterfd = -1) const;
 		std::vector<vm_area> GetMMaps(const Process& p);
 
 		status_t RegisterSyscall(SyscallEvent& ev);
@@ -186,8 +187,9 @@ namespace libvmtrace
 		addr_t _thread_struct_offset, _sp_offset, _sp0_offset, _sp_on_pt_regs_offset, _ip_on_pt_regs_offset, _current_task_offset;
 		addr_t _socket_type_offset, _socket_family;
 
-		std::string d_path(addr_t path, vmi_instance_t vmi);
-		uint32_t create_path(addr_t dentry, char* buf, vmi_instance_t vmi);
+		std::string d_path(addr_t path, vmi_instance_t vmi) const;
+		uint32_t create_path(addr_t dentry, char* buf, vmi_instance_t vmi) const;
+		Process taskstruct_to_Process(addr_t current_process, vmi_instance_t vmi) const;
 
 		addr_t GetSyscallAddrVA(unsigned int syscall_nr, bool is32bit, vmi_instance_t vmi);
 		addr_t GetSyscallAddrPA(unsigned int syscall_nr, bool is32bit, vmi_instance_t vmi);


### PR DESCRIPTION
Tested with simple mounts, nested mounts, bind mounts in kernel 4.4
(no support for old kernel < 2.x with different data structures)